### PR TITLE
Add basic ton conversion

### DIFF
--- a/lib.js
+++ b/lib.js
@@ -37,6 +37,16 @@ var conversions = [
     target: " kg",
     conversion: x => x * 0.4536
   },
+  {
+    regex: /short tons?|[uU][sS] tons?/,
+    target: " metric ton",
+    conversion: x => x * 0.907185
+  },
+  {
+    regex: /long tons?|imperial tons?/,
+    target: " metric ton",
+    conversion: x => x * 1.01605
+  },
   // Temperature
   // Fahrenheit needs to be earlier in the list than F so that arr.find()
   // first tries to match the full Fahrenheit

--- a/test-lib.js
+++ b/test-lib.js
@@ -32,6 +32,11 @@ let tests = {
   "100 mph": "160.93 kph",
   "Don't drive faster than 80mi/h!": "Don't drive faster than 128.75 km/h!",
   "20 miles per hour": "32.19 km per hour",
+  // ton
+  "100 short ton": "90.72 metric ton",
+  "1 US ton": "0.91 metric ton",
+  "10 long ton": "10.16 metric ton",
+  "10 imperial ton": "10.16 metric ton",
 }
 
 let count = 0


### PR DESCRIPTION
#8 Better than nothing.
The question is: should the result rather be "tonne" or "metric ton"?