### PR TITLE
Plural

### DIFF
--- a/lib.js
+++ b/lib.js
@@ -1,67 +1,43 @@
-var conversions = [
+if (!conversions) {
+  var conversions = []
+
+  let addConv = function(regex, target, fun) {
+    conversions.push({
+      regex: regex,
+      target: target,
+      conversion: fun,
+    })
+  }
+
+  let mile_to_m = x => x * 1.609344
+  let f_to_c = x => (x - 32) * 5 / 9
+
   // Length
-  {
-    regex: /inch(es)?|in\.?/,
-    target: " cm",
-    conversion: x => x * 2.54
-  },
-  {
-    regex: /foot|feet|ft\.?/,
-    target: " m",
-    conversion: x => x * 0.3048
-  },
-  {
-    regex: /yards?|yd\.?/,
-    target: " m",
-    conversion: x => x * 0.9144
-  },
-  {
-    regex: /miles?|mi\.?/,
-    target: " km",
-    conversion: x => x * 1.609344
-  },
-  // speed
-  {
-    regex: /mph/,
-    target: " kph",
-    conversion: x => x * 1.609344
-  },
+  addConv(/inch(es)?|in\.?/, " cm", x => x * 2.54)
+  addConv(/foot|feet|ft\.?/, " m", x => x * 0.3048)
+  addConv(/yards?|yd\.?/, " m", x => x * 0.9144)
+  addConv(/miles?|mi\.?/, " km", mile_to_m)
+  // Speed
+  addConv(/mph/, " kph", mile_to_m)
   // Mass
-  {
-    regex: /ounces?|oz/,
-    target: " g",
-    conversion: x => x * 28.35
-  },
-  {
-    regex: /pounds?|lb[s\.]?/,
-    target: " kg",
-    conversion: x => x * 0.4536
-  },
+  addConv(/ounces?|oz/, " g", x => x * 28.35)
+  addConv(/pounds?|lb[s\.]?/, " kg", x => x * 0.4536)
   // Temperature
   // Fahrenheit needs to be earlier in the list than F so that arr.find()
   // first tries to match the full Fahrenheit
-  {
-    regex: /°\s?Fahrenheit/,
-    target: "° Celsius",
-    conversion: x => (x - 32) * 5 / 9
-  },
-  {
-    regex: /°\s?F/,
-    target: "° C",
-    conversion: x => (x - 32) * 5 / 9
-  }
-]
+  addConv(/°\s?Fahrenheit/, "° Celsius", f_to_c)
+  addConv(/°\s?F/, "° C", f_to_c)
 
-// Should match any number (does it?)
-// Negatives are relative for Fahrenheit conversion
-// These are different characters: - (char code 45) and − (char code 8722)
-var re_number = /[−\-]?\d+(\.\d+)?/
+  // Should match any number (does it?)
+  // Negatives are relative for Fahrenheit conversion
+  // These are different characters: - (char code 45) and − (char code 8722)
+  let re_number = /[−\-]?\d+(\.\d+)?/
 
-// "One RegExp to rule them all, One RegExp to find them ..."
-var re_all = new RegExp("(" + re_number.source + ")\\s?("
-                            + conversions.map(x => x.regex.source).join("|")
-                            + ")\\b",
-                          "gi")
+  // "One RegExp to rule them all, One RegExp to find them ..."
+  var re_all = new RegExp("(" + re_number.source + ")\\s?("
+                              + conversions.map(x => x.regex.source).join("|")
+                              + ")\\b", "gi")
+}
 
 /**
 * Replaces all occurences of imperial units in a string with appropriate metric

--- a/test-lib.js
+++ b/test-lib.js
@@ -46,6 +46,10 @@ let tests = {
   "10 imperial ton": "10.16 metric tons",
   // Plural
   "1.102 short tons": "1 metric ton",
+  // Delimiter
+  "1\tlb": "0.45\tkg",
+  "1\nlb": "0.45\nkg",
+  "1  lb": null, // only singular whitespace is currently supported
 }
 
 function runTests(silent) {

--- a/test-lib.js
+++ b/test-lib.js
@@ -12,21 +12,21 @@ const lib = require("./lib.js")
 // `expected-result` may be `null` if we don't expect changes.
 let tests = {
   // mile -> km
-  "1 mile": "1.61 km",
-  "0.62 mile": "1 km",
+  "1 mile": "1.61 kilometers",
+  "0.62 miles": "1 kilometer",
   "20mi": "32.19 km",
-  "100 miles is longer than 1 mile": "160.93 km is longer than 1.61 km",
+  "100 miles is longer than 1 mile": "160.93 kilometers is longer than 1.61 kilometers",
   "A \"mil\" should be ignored as in 10 milion": null,
   "There are 2 milestones": null,
   // pounds -> kilos
-  "1 pound": "0.45 kg",
-  "0.5 pound": "0.23 kg",
+  "1 pound": "0.45 kilograms",
+  "0.5 pound": "0.23 kilograms",
   "1 lb": "0.45 kg",
   "No space between num and unit: 2.2lbs.": "No space between num and unit: 1 kg.",
   // inch -> centimeter
-  "1 inch": "2.54 cm",
+  "1 inch": "2.54 centimeters",
   "2 in. is short": "5.08 cm. is short",
-  "12 inches": "30.48 cm",
+  "12 inches": "30.48 centimeters",
   "2 inchworms are crawling.": null,
   // Fahrenheit -> Celsius
   "Water boils at 212° Fahrenheit.": "Water boils at 100° Celsius.",
@@ -36,14 +36,16 @@ let tests = {
   "-40°F": "-40° C",
   "10° Fusel": null,
   // miles per hour
-  "100 mph": "160.93 kph",
+  "100 mph": "160.93 km/h",
   "Don't drive faster than 80mi/h!": "Don't drive faster than 128.75 km/h!",
-  "20 miles per hour": "32.19 km per hour",
+  "20 miles per hour": "32.19 kilometers per hour",
   // ton
-  "100 short ton": "90.72 metric ton",
-  "1 US ton": "0.91 metric ton",
-  "10 long ton": "10.16 metric ton",
-  "10 imperial ton": "10.16 metric ton",
+  "100 short tons": "90.72 metric tons",
+  "1 US ton": "0.91 metric tons",
+  "10 long ton": "10.16 metric tons",
+  "10 imperial ton": "10.16 metric tons",
+  // Plural
+  "1.102 short tons": "1 metric ton",
 }
 
 function runTests(silent) {


### PR DESCRIPTION
Uses the full words rather than the abbreviations if the original text did the same.
Also:
- mph converts to km/h instead of kph
- The delimiters of the original text are kept